### PR TITLE
fix: endurecer fluxo de nf e revisão manual

### DIFF
--- a/lib/list_details/presentation/components/list_item_card.dart
+++ b/lib/list_details/presentation/components/list_item_card.dart
@@ -197,7 +197,7 @@ class ListItemCard extends StatelessWidget {
                 padding: const EdgeInsets.only(right: 4),
                 child: TextButton.icon(
                   onPressed: () {
-                    listDetailsBloc!.add(SugerirPreco(item));
+                    listDetailsBloc.add(SugerirPreco(item));
                   },
                   icon: const Icon(Icons.auto_awesome, size: 16),
                   label: const Text(

--- a/lib/list_details/presentation/screens/close_purchase_with_nfe_screen.dart
+++ b/lib/list_details/presentation/screens/close_purchase_with_nfe_screen.dart
@@ -19,10 +19,12 @@ class ClosePurchaseWithNfeScreen extends StatefulWidget {
 
 class _ClosePurchaseWithNfeScreenState
     extends State<ClosePurchaseWithNfeScreen> {
+  static const String _ignoreCartItemSelection = '__ignore_cart_item__';
+
   final _keyController = TextEditingController();
   final _repository = sl<ListasRepository>();
   PurchaseWithNfePreview? _preview;
-  Map<String, String?> _manualMatches = {};
+  Map<String, String> _manualMatches = {};
   bool _isLoading = false;
   bool _isConfirming = false;
   String? _error;
@@ -62,7 +64,8 @@ class _ClosePurchaseWithNfeScreenState
 
       if (item.status == CartReviewStatus.ambiguous) {
         final manualSelection = _manualMatches[item.cartItemId];
-        if (manualSelection != null) {
+        if (manualSelection != null &&
+            manualSelection != _ignoreCartItemSelection) {
           selectedIds.add(manualSelection);
         }
       }
@@ -102,7 +105,10 @@ class _ClosePurchaseWithNfeScreenState
           matchedItemsCount += 1;
           break;
         case CartReviewStatus.ambiguous:
-          if (_manualMatches[item.cartItemId] != null) {
+          final manualSelection = _manualMatches[item.cartItemId];
+          if (manualSelection == _ignoreCartItemSelection) {
+            unmatchedItemsCount += 1;
+          } else if (manualSelection != null) {
             matchedItemsCount += 1;
           } else {
             ambiguousItemsCount += 1;
@@ -166,12 +172,7 @@ class _ClosePurchaseWithNfeScreenState
       if (!mounted) return;
       setState(() {
         _preview = preview;
-        _manualMatches = {
-          for (final item in preview.cartItems.where(
-            (item) => item.needsReview,
-          ))
-            item.cartItemId: null,
-        };
+        _manualMatches = {};
       });
     } catch (e) {
       if (!mounted) return;
@@ -195,7 +196,11 @@ class _ClosePurchaseWithNfeScreenState
       await _repository.confirmPurchaseWithNfe(
         _cartItemIds,
         _keyController.text.trim(),
-        _manualMatches,
+        {
+          for (final entry in _manualMatches.entries)
+            entry.key:
+                entry.value == _ignoreCartItemSelection ? null : entry.value,
+        },
       );
       if (!mounted) return;
       context.read<CartBloc>().add(LoadCart());
@@ -242,8 +247,16 @@ class _ClosePurchaseWithNfeScreenState
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    return WillPopScope(
-      onWillPop: _confirmExit,
+    return PopScope<void>(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) async {
+        if (didPop) return;
+
+        final shouldLeave = await _confirmExit();
+        if (shouldLeave && context.mounted) {
+          Navigator.of(context).pop();
+        }
+      },
       child: Scaffold(
         appBar: AppBar(title: const Text('Fechar compra com nota')),
         body: ListView(
@@ -426,8 +439,8 @@ class _ClosePurchaseWithNfeScreenState
                   border: OutlineInputBorder(),
                 ),
                 items: [
-                  const DropdownMenuItem<String?>(
-                    value: null,
+                  const DropdownMenuItem<String>(
+                    value: _ignoreCartItemSelection,
                     child: Text(
                       'Desconsiderar item da cesta',
                       overflow: TextOverflow.ellipsis,
@@ -473,7 +486,11 @@ class _ClosePurchaseWithNfeScreenState
                     ],
                 onChanged: (value) {
                   setState(() {
-                    _manualMatches[item.cartItemId] = value;
+                    if (value == null) {
+                      _manualMatches.remove(item.cartItemId);
+                    } else {
+                      _manualMatches[item.cartItemId] = value;
+                    }
                   });
                 },
               ),

--- a/lib/mercado/data/mercado_repository.dart
+++ b/lib/mercado/data/mercado_repository.dart
@@ -35,7 +35,18 @@ class MercadoRepository {
   MercadoRepository({required SupabaseClient client}) : _client = client;
 
   Future<void> sendNfe(String nfe) async {
-    await _client.functions.invoke('scrape-nfce', body: {'chave_acesso': nfe});
+    final response = await _client.functions.invoke(
+      'scrape-nfce',
+      body: {'chave_acesso': nfe},
+    );
+
+    if (response.status != 200) {
+      final data = response.data;
+      if (data is Map<String, dynamic> && data['error'] is String) {
+        throw data['error'] as String;
+      }
+      throw 'Falha ao enviar nota fiscal.';
+    }
   }
 
   Future<PurchaseHistory> getNfeById(String notaFiscalId) async {

--- a/supabase/functions/_shared/nfce.ts
+++ b/supabase/functions/_shared/nfce.ts
@@ -58,6 +58,15 @@ export type CartItemForMatching = {
   list_name: string;
 };
 
+export class HttpError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
 export type InvoiceMatchCandidate = {
   invoice_item_temp_id: string;
   product_name: string;
@@ -423,6 +432,105 @@ export async function previewInvoiceMatches(
       invoice_extra_items_count: extraItems.length,
     },
   };
+}
+
+export async function loadAuthorizedCartItemsForInvoiceFlow({
+  supabaseAdmin,
+  userId,
+  cartItemIds,
+}: {
+  supabaseAdmin: any;
+  userId: string;
+  cartItemIds: string[];
+}): Promise<CartItemForMatching[]> {
+  const uniqueCartItemIds = Array.from(new Set(cartItemIds));
+  if (uniqueCartItemIds.length !== cartItemIds.length) {
+    throw new HttpError(
+      400,
+      "A requisição contém itens duplicados do carrinho.",
+    );
+  }
+
+  const { data: cartItems, error: cartError } = await supabaseAdmin
+    .from("cart_items")
+    .select(
+      "id, user_id, list_items!inner(id, name, amount, unit_id, list_id, lists!inner(id, name, cart_mode), units(id, abbreviation))",
+    )
+    .in("id", uniqueCartItemIds);
+
+  if (cartError) {
+    throw new HttpError(
+      500,
+      `Erro ao carregar itens do carrinho: ${cartError.message}`,
+    );
+  }
+
+  if (!cartItems?.length) {
+    throw new HttpError(404, "Nenhum item do carrinho foi encontrado.");
+  }
+
+  if (cartItems.length !== uniqueCartItemIds.length) {
+    throw new HttpError(
+      403,
+      "Há itens do carrinho inacessíveis para o usuário autenticado.",
+    );
+  }
+
+  const listIds = new Set(
+    cartItems.map((item: any) => item.list_items.list_id as string),
+  );
+  if (listIds.size !== 1) {
+    throw new HttpError(
+      400,
+      "A compra com NF deve pertencer a uma única lista.",
+    );
+  }
+
+  const listId = cartItems[0].list_items.list_id as string;
+  const listMode = cartItems[0].list_items.lists?.cart_mode as string? ?? "shared";
+
+  const { data: membership, error: membershipError } = await supabaseAdmin
+    .from("list_members")
+    .select("user_id")
+    .eq("list_id", listId)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (membershipError) {
+    throw new HttpError(
+      500,
+      `Erro ao validar acesso à lista: ${membershipError.message}`,
+    );
+  }
+
+  if (!membership) {
+    throw new HttpError(
+      403,
+      "O usuário autenticado não tem acesso à lista informada.",
+    );
+  }
+
+  if (listMode === "individual") {
+    const hasForeignItems = cartItems.some((item: any) => item.user_id !== userId);
+    if (hasForeignItems) {
+      throw new HttpError(
+        403,
+        "No modo individual, só é permitido revisar ou confirmar itens do próprio usuário.",
+      );
+    }
+  }
+
+  return cartItems.map((cartItem: any) => ({
+    cart_item_id: cartItem.id,
+    list_item_id: cartItem.list_items.id,
+    user_id: cartItem.user_id,
+    name: cartItem.list_items.name,
+    amount: Number(cartItem.list_items.amount ?? 0),
+    unit_id: cartItem.list_items.unit_id ?? null,
+    unit_label: cartItem.list_items.units?.abbreviation ?? null,
+    list_id: cartItem.list_items.list_id,
+    list_name: cartItem.list_items.lists.name,
+  }));
 }
 
 export async function persistInvoiceData(

--- a/supabase/functions/confirm-purchase-with-nf/index.ts
+++ b/supabase/functions/confirm-purchase-with-nf/index.ts
@@ -1,6 +1,8 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import {
   corsHeaders,
+  HttpError,
+  loadAuthorizedCartItemsForInvoiceFlow,
   persistInvoiceData,
   previewInvoiceMatches,
   scrapeNfce,
@@ -81,10 +83,10 @@ Deno.serve(async (req) => {
   try {
     const { cart_items_ids, chave_acesso, manual_matches } = await req.json();
     if (!Array.isArray(cart_items_ids) || cart_items_ids.length === 0) {
-      throw new Error("Nenhum item do carrinho para confirmar.");
+      throw new HttpError(400, "Nenhum item do carrinho para confirmar.");
     }
     if (!chave_acesso) {
-      throw new Error("Chave de acesso é obrigatória.");
+      throw new HttpError(400, "Chave de acesso é obrigatória.");
     }
 
     const authHeader = req.headers.get("Authorization");
@@ -104,35 +106,11 @@ Deno.serve(async (req) => {
       });
     }
 
-    const { data: cartItems, error: cartError } = await supabaseAdmin
-      .from("cart_items")
-      .select(
-        "id, user_id, list_items!inner(id, name, amount, unit_id, list_id, lists!inner(id, name), units(id, abbreviation))",
-      )
-      .in("id", cart_items_ids);
-
-    if (cartError || !cartItems?.length) {
-      throw new Error(`Erro ao carregar itens do carrinho: ${cartError?.message ?? ""}`);
-    }
-
-    const listIds = new Set(
-      cartItems.map((item: any) => item.list_items.list_id as string),
-    );
-    if (listIds.size !== 1) {
-      throw new Error("A compra com NF deve pertencer a uma única lista.");
-    }
-
-    const reviewItems: CartItemForMatching[] = cartItems.map((cartItem: any) => ({
-      cart_item_id: cartItem.id,
-      list_item_id: cartItem.list_items.id,
-      user_id: cartItem.user_id,
-      name: cartItem.list_items.name,
-      amount: Number(cartItem.list_items.amount ?? 0),
-      unit_id: cartItem.list_items.unit_id ?? null,
-      unit_label: cartItem.list_items.units?.abbreviation ?? null,
-      list_id: cartItem.list_items.list_id,
-      list_name: cartItem.list_items.lists.name,
-    }));
+    const reviewItems = await loadAuthorizedCartItemsForInvoiceFlow({
+      supabaseAdmin,
+      userId: user.id,
+      cartItemIds: cart_items_ids,
+    });
 
     const invoice = await scrapeNfce(chave_acesso);
     const preview = await previewInvoiceMatches(reviewItems, invoice);
@@ -309,10 +287,11 @@ Deno.serve(async (req) => {
       notaFiscalId: createdNotaFiscalId,
     });
 
+    const status = error instanceof HttpError ? error.status : 500;
     return new Response(
       JSON.stringify({ error: error.message }),
       {
-        status: 500,
+        status,
         headers: { ...corsHeaders, "Content-Type": "application/json" },
       },
     );

--- a/supabase/functions/preview-purchase-with-nf/index.ts
+++ b/supabase/functions/preview-purchase-with-nf/index.ts
@@ -1,9 +1,10 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import {
   corsHeaders,
+  HttpError,
+  loadAuthorizedCartItemsForInvoiceFlow,
   previewInvoiceMatches,
   scrapeNfce,
-  type CartItemForMatching,
 } from "../_shared/nfce.ts";
 
 Deno.serve(async (req) => {
@@ -14,10 +15,10 @@ Deno.serve(async (req) => {
   try {
     const { cart_items_ids, chave_acesso } = await req.json();
     if (!Array.isArray(cart_items_ids) || cart_items_ids.length === 0) {
-      throw new Error("Nenhum item do carrinho para revisar.");
+      throw new HttpError(400, "Nenhum item do carrinho para revisar.");
     }
     if (!chave_acesso) {
-      throw new Error("Chave de acesso é obrigatória.");
+      throw new HttpError(400, "Chave de acesso é obrigatória.");
     }
 
     const authHeader = req.headers.get("Authorization");
@@ -41,36 +42,11 @@ Deno.serve(async (req) => {
       Deno.env.get("SUPABASE_URL")!,
       Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
     );
-
-    const { data: cartItems, error: cartError } = await supabaseAdmin
-      .from("cart_items")
-      .select(
-        "id, user_id, list_items!inner(id, name, amount, unit_id, list_id, lists!inner(id, name), units(id, abbreviation))",
-      )
-      .in("id", cart_items_ids);
-
-    if (cartError || !cartItems?.length) {
-      throw new Error(`Erro ao carregar itens do carrinho: ${cartError?.message ?? ""}`);
-    }
-
-    const listIds = new Set(
-      cartItems.map((item: any) => item.list_items.list_id as string),
-    );
-    if (listIds.size !== 1) {
-      throw new Error("A compra com NF deve pertencer a uma única lista.");
-    }
-
-    const reviewItems: CartItemForMatching[] = cartItems.map((cartItem: any) => ({
-      cart_item_id: cartItem.id,
-      list_item_id: cartItem.list_items.id,
-      user_id: cartItem.user_id,
-      name: cartItem.list_items.name,
-      amount: Number(cartItem.list_items.amount ?? 0),
-      unit_id: cartItem.list_items.unit_id ?? null,
-      unit_label: cartItem.list_items.units?.abbreviation ?? null,
-      list_id: cartItem.list_items.list_id,
-      list_name: cartItem.list_items.lists.name,
-    }));
+    const reviewItems = await loadAuthorizedCartItemsForInvoiceFlow({
+      supabaseAdmin,
+      userId: user.id,
+      cartItemIds: cart_items_ids,
+    });
 
     const invoice = await scrapeNfce(chave_acesso);
     const matchPreview = await previewInvoiceMatches(reviewItems, invoice);
@@ -85,10 +61,11 @@ Deno.serve(async (req) => {
       },
     );
   } catch (error) {
+    const status = error instanceof HttpError ? error.status : 500;
     return new Response(
       JSON.stringify({ error: error.message }),
       {
-        status: 500,
+        status,
         headers: { ...corsHeaders, "Content-Type": "application/json" },
       },
     );


### PR DESCRIPTION
## Resumo
Este PR trata o primeiro lote da Prioridade 1 da passagem de qualidade.

## O que foi corrigido
- endurece a autorização dos endpoints `preview-purchase-with-nf` e `confirm-purchase-with-nf`
- impede confirmação da compra com NF antes da revisão explícita dos itens ambíguos
- valida o `status` da edge function `scrape-nfce` no app antes de sinalizar sucesso
- melhora o contrato HTTP dos endpoints afetados para erros de payload/autorização

## Issues
- closes #16
- closes #21
- closes #22

## Validação
- `flutter analyze`
- `flutter test` *(falha por problema pré-existente nos mocks de realtime de `ListDetailsBloc`, sem relação com este PR)*