### PR TITLE
fix: endurecer contratos das funcoes de nf

### DIFF
--- a/supabase/functions/_shared/nfce.ts
+++ b/supabase/functions/_shared/nfce.ts
@@ -545,7 +545,10 @@ export async function persistInvoiceData(
     .maybeSingle();
 
   if (existingInvoice) {
-    throw new Error("Esta nota fiscal já foi processada anteriormente.");
+    throw new HttpError(
+      409,
+      "Esta nota fiscal já foi processada anteriormente.",
+    );
   }
 
   const { data: mercado, error: mercadoError } = await supabaseAdmin

--- a/supabase/functions/scrape-nfce/index.ts
+++ b/supabase/functions/scrape-nfce/index.ts
@@ -2,6 +2,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import {
   corsHeaders,
+  HttpError,
   persistInvoiceData,
   scrapeNfce,
 } from "../_shared/nfce.ts";
@@ -14,7 +15,7 @@ serve(async (req) => {
   try {
     const { chave_acesso } = await req.json();
     if (!chave_acesso) {
-      throw new Error("Chave de acesso é obrigatória");
+      throw new HttpError(400, "Chave de acesso é obrigatória");
     }
 
     const authHeader = req.headers.get("Authorization");
@@ -28,7 +29,7 @@ serve(async (req) => {
       data: { user },
     } = await supabase.auth.getUser();
     if (!user) {
-      throw new Error("Usuário não autenticado.");
+      throw new HttpError(401, "Usuário não autenticado.");
     }
 
     const invoice = await scrapeNfce(chave_acesso);
@@ -50,10 +51,11 @@ serve(async (req) => {
     );
   } catch (error) {
     console.error(error);
+    const status = error instanceof HttpError ? error.status : 500;
     return new Response(
       JSON.stringify({ error: error.message }),
       {
-        status: 500,
+        status,
         headers: { ...corsHeaders, "Content-Type": "application/json" },
       },
     );

--- a/supabase/functions/sugerir-preco/index.ts
+++ b/supabase/functions/sugerir-preco/index.ts
@@ -28,6 +28,24 @@ async function getEmbedding(text: string, apiKey: string): Promise<number[]> {
   return data.embedding.values;
 }
 
+async function clearDerivedSuggestionData(
+  supabaseClient: ReturnType<typeof createClient>,
+  itemId: string,
+) {
+  await supabaseClient
+    .from("list_item_product_matches")
+    .delete()
+    .eq("list_item_id", itemId);
+
+  await supabaseClient
+    .from("list_items")
+    .update({
+      preco_sugerido: null,
+      unidade_preco_sugerido: null,
+    })
+    .eq("id", itemId);
+}
+
 serve(async (req) => {
   try {
     const supabaseClient = createClient(
@@ -73,6 +91,7 @@ serve(async (req) => {
     if (rpcError) throw rpcError;
 
     if (!matchedProducts || matchedProducts.length === 0) {
+      await clearDerivedSuggestionData(supabaseClient, itemId);
       console.log(`Nenhum produto encontrado com similaridade aceitável para "${itemName}".`);
       return new Response(JSON.stringify({ message: "Nenhum produto compatível encontrado." }), { status: 200 });
     }
@@ -107,6 +126,10 @@ serve(async (req) => {
 
       console.log(`Preço sugerido de ${bestMatch.valor_unitario} (Unidade: ${productData?.unidade_medida}) para "${itemName}" (baseado no match mais similar: "${bestMatch.nome}" com ${(bestMatch.similarity * 100).toFixed(1)}%).`);
     } else {
+      await supabaseClient.from("list_items").update({
+        preco_sugerido: null,
+        unidade_preco_sugerido: null
+      }).eq("id", itemId);
       console.log(`Produtos similares a "${itemName}" encontrados, mas nenhum com preço.`);
     }
 


### PR DESCRIPTION
## Resumo
Este PR trata o lote backend da Prioridade 2 da passagem de qualidade.

## O que foi corrigido
- `scrape-nfce` agora devolve status HTTP coerente para validação, autenticação e conflito de nota já processada
- `persistInvoiceData` passou a sinalizar conflito de chave de acesso como `409`
- `sugerir-preco` agora limpa matches e preço sugerido quando não encontra novo resultado válido

## Issues
- closes #25
- closes #26

## Validação
- `flutter analyze`