### PR TITLE
fix: reforcar feedback e fallbacks de ui

### DIFF
--- a/lib/list_details/presentation/components/list_item_card.dart
+++ b/lib/list_details/presentation/components/list_item_card.dart
@@ -31,6 +31,7 @@ class ListItemCard extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
     final listDetailsBloc = context.watch<ListDetailsBloc?>();
     final listDetailsState = listDetailsBloc?.state;
+    final avatarUrl = item.createdBy.userMetadata?['picture'] as String?;
 
     final bool priceForecastEnabled =
         listDetailsState?.list?.priceForecastEnabled ?? false;
@@ -130,11 +131,17 @@ class ListItemCard extends StatelessWidget {
                     children: [
                       ClipRRect(
                         borderRadius: BorderRadius.circular(24),
-                        child: Image.network(
-                          item.createdBy.userMetadata?['picture'],
-                          height: 20,
-                          width: 20,
-                        ),
+                        child:
+                            avatarUrl != null
+                                ? Image.network(
+                                  avatarUrl,
+                                  height: 20,
+                                  width: 20,
+                                  errorBuilder: (_, _, _) {
+                                    return _buildAvatarFallback(context);
+                                  },
+                                )
+                                : _buildAvatarFallback(context),
                       ),
                       const SizedBox(width: 4),
                       const Icon(Icons.calendar_month, size: 14),
@@ -233,6 +240,16 @@ class ListItemCard extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildAvatarFallback(BuildContext context) {
+    return Container(
+      width: 20,
+      height: 20,
+      color: Theme.of(context).colorScheme.surfaceContainerHighest,
+      alignment: Alignment.center,
+      child: const Icon(Icons.person, size: 14),
     );
   }
 }

--- a/lib/list_details/presentation/screens/list_history_screen.dart
+++ b/lib/list_details/presentation/screens/list_history_screen.dart
@@ -26,6 +26,36 @@ class _ListHistoryScreenState extends State<ListHistoryScreen> {
             return const Center(child: CircularProgressIndicator());
           }
 
+          if (state.error != null && state.purchaseHistory.isEmpty) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      'Não foi possível carregar o histórico de compras.',
+                      style: Theme.of(context).textTheme.titleMedium,
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      state.error!,
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 16),
+                    FilledButton(
+                      onPressed: () {
+                        context.read<HistoryBloc>().add(LoadHistory());
+                      },
+                      child: const Text('Tentar novamente'),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }
+
           if (state.purchaseHistory.isEmpty) {
             return const Center(
               child: Text("Nenhuma compra foi registrada ainda."),

--- a/lib/mercado/presentation/enviar_nota_screen.dart
+++ b/lib/mercado/presentation/enviar_nota_screen.dart
@@ -52,16 +52,18 @@ class _EnviarNotaScreenState extends State<EnviarNotaScreen> {
       return;
     }
 
+    final messenger = ScaffoldMessenger.of(context);
+    final mercadoBloc = context.read<MercadoBloc>();
     context.pop();
 
-    ScaffoldMessenger.of(context).showSnackBar(
+    messenger.showSnackBar(
       const SnackBar(
         content: Text('QR Code lido com sucesso! Enviando nota...'),
         backgroundColor: Colors.blue,
       ),
     );
 
-    context.read<MercadoBloc>().add(SendNfe(accessKey));
+    mercadoBloc.add(SendNfe(accessKey));
   }
 
   void _showErrorSnackBar(String message) {

--- a/lib/shared/widgets/user_avatar.dart
+++ b/lib/shared/widgets/user_avatar.dart
@@ -7,13 +7,15 @@ class UserAvatar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final avatarUrl =
+        supabase.auth.currentUser?.userMetadata?['avatar_url'] as String?;
+
     return Padding(
       padding: const EdgeInsets.all(6),
       child: CircleAvatar(
         radius: size / 2,
-        foregroundImage: NetworkImage(
-          supabase.auth.currentUser!.userMetadata!["avatar_url"],
-        ),
+        foregroundImage: avatarUrl != null ? NetworkImage(avatarUrl) : null,
+        child: avatarUrl == null ? const Icon(Icons.person_outline) : null,
       ),
     );
   }


### PR DESCRIPTION
## Resumo
Este PR trata o lote de UI/feedback da Prioridade 2 da passagem de qualidade.

## O que foi corrigido
- evita uso inseguro de `context` depois do `pop()` no scanner de NF
- diferencia erro de carregamento de histórico do estado vazio
- adiciona fallback seguro para avatar do usuário em widgets compartilhados

## Issues
- closes #29
- closes #30
- closes #35

## Validação
- `flutter analyze`