### PR TITLE
fix: corrigir issues da semana 1

### DIFF
--- a/lib/list_details/presentation/components/list_item_card.dart
+++ b/lib/list_details/presentation/components/list_item_card.dart
@@ -31,15 +31,14 @@ class ListItemCard extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
     final listDetailsBloc = context.watch<ListDetailsBloc?>();
     final listDetailsState = listDetailsBloc?.state;
-    final avatarUrl = item.createdBy.userMetadata?['picture'] as String?;
+    final avatarUrl =
+        item.createdBy.userMetadata?['avatar_url'] as String? ??
+        item.createdBy.userMetadata?['picture'] as String?;
 
     final bool priceForecastEnabled =
         listDetailsState?.list?.priceForecastEnabled ?? false;
     final bool hasAnySuggestedPrice =
-        listDetailsState?.items.any(
-      (i) => i.precoSugerido != null,
-    ) ??
-        false;
+        listDetailsState?.items.any((i) => i.precoSugerido != null) ?? false;
 
     final bool isSuggestingPrice =
         listDetailsState?.suggestingPriceItemId == item.id;

--- a/lib/mercado/presentation/enviar_nota_screen.dart
+++ b/lib/mercado/presentation/enviar_nota_screen.dart
@@ -54,7 +54,7 @@ class _EnviarNotaScreenState extends State<EnviarNotaScreen> {
 
     final messenger = ScaffoldMessenger.of(context);
     final mercadoBloc = context.read<MercadoBloc>();
-    context.pop();
+    mercadoBloc.add(SendNfe(accessKey));
 
     messenger.showSnackBar(
       const SnackBar(
@@ -63,7 +63,7 @@ class _EnviarNotaScreenState extends State<EnviarNotaScreen> {
       ),
     );
 
-    mercadoBloc.add(SendNfe(accessKey));
+    context.pop();
   }
 
   void _showErrorSnackBar(String message) {

--- a/lib/shared/widgets/user_avatar.dart
+++ b/lib/shared/widgets/user_avatar.dart
@@ -7,14 +7,16 @@ class UserAvatar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final metadata = supabase.auth.currentUser?.userMetadata;
     final avatarUrl =
-        supabase.auth.currentUser?.userMetadata?['avatar_url'] as String?;
+        metadata?['avatar_url'] as String? ?? metadata?['picture'] as String?;
 
     return Padding(
       padding: const EdgeInsets.all(6),
       child: CircleAvatar(
         radius: size / 2,
         foregroundImage: avatarUrl != null ? NetworkImage(avatarUrl) : null,
+        onForegroundImageError: (_, _) {},
         child: avatarUrl == null ? const Icon(Icons.person_outline) : null,
       ),
     );

--- a/supabase/functions/_shared/nfce.ts
+++ b/supabase/functions/_shared/nfce.ts
@@ -534,11 +534,14 @@ export async function loadAuthorizedCartItemsForInvoiceFlow({
 }
 
 export async function persistInvoiceData(
-  supabaseAdmin: any,
+  supabaseClient: any,
   userId: string,
   invoice: CleanedInvoiceData,
+  options?: {
+    authorizationHeader?: string;
+  },
 ): Promise<PersistedInvoiceData> {
-  const { data: existingInvoice } = await supabaseAdmin
+  const { data: existingInvoice } = await supabaseClient
     .from("notas_fiscais")
     .select("id")
     .eq("chave_acesso", invoice.chave_acesso)
@@ -551,7 +554,7 @@ export async function persistInvoiceData(
     );
   }
 
-  const { data: mercado, error: mercadoError } = await supabaseAdmin
+  const { data: mercado, error: mercadoError } = await supabaseClient
     .from("mercados")
     .upsert(
       {
@@ -582,7 +585,7 @@ export async function persistInvoiceData(
     ).values(),
   );
 
-  const { data: persistedProducts, error: productsError } = await supabaseAdmin
+  const { data: persistedProducts, error: productsError } = await supabaseClient
     .from("produtos")
     .upsert(
       uniqueProducts.map((product) => ({
@@ -604,7 +607,7 @@ export async function persistInvoiceData(
     productByLookup.set(lookupKey, product.id);
   }
 
-  const { data: notaFiscal, error: notaFiscalError } = await supabaseAdmin
+  const { data: notaFiscal, error: notaFiscalError } = await supabaseClient
     .from("notas_fiscais")
     .insert({
       chave_acesso: invoice.chave_acesso,
@@ -633,7 +636,7 @@ export async function persistInvoiceData(
     };
   });
 
-  const { data: invoiceItems, error: invoiceItemsError } = await supabaseAdmin
+  const { data: invoiceItems, error: invoiceItemsError } = await supabaseClient
     .from("itens_nota_fiscal")
     .insert(
       invoiceRows.map((row) => ({
@@ -662,12 +665,18 @@ export async function persistInvoiceData(
     });
   });
 
+  const batchEmbedHeaders: Record<string, string> = {
+    "Content-Type": "application/json",
+    apikey: Deno.env.get("SUPABASE_ANON_KEY")!,
+  };
+
+  if (options?.authorizationHeader) {
+    batchEmbedHeaders.Authorization = options.authorizationHeader;
+  }
+
   fetch(`${Deno.env.get("SUPABASE_URL")}/functions/v1/batch-embed`, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")}`,
-    },
+    headers: batchEmbedHeaders,
     body: JSON.stringify({}),
   }).catch(() => {});
 

--- a/supabase/functions/confirm-purchase-with-nf/index.ts
+++ b/supabase/functions/confirm-purchase-with-nf/index.ts
@@ -160,7 +160,12 @@ Deno.serve(async (req) => {
       );
     }
 
-    const persistedInvoice = await persistInvoiceData(supabaseAdmin, user.id, invoice);
+    const persistedInvoice = await persistInvoiceData(
+      supabaseAdmin,
+      user.id,
+      invoice,
+      { authorizationHeader: authHeader ?? undefined },
+    );
     createdNotaFiscalId = persistedInvoice.notaFiscalId;
 
     const { data: history, error: historyError } = await supabaseAdmin

--- a/supabase/functions/scrape-nfce/index.ts
+++ b/supabase/functions/scrape-nfce/index.ts
@@ -33,14 +33,11 @@ serve(async (req) => {
     }
 
     const invoice = await scrapeNfce(chave_acesso);
-    const supabaseAdmin = createClient(
-      Deno.env.get("SUPABASE_URL")!,
-      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
-    );
     const persistedInvoice = await persistInvoiceData(
-      supabaseAdmin,
+      supabase,
       user.id,
       invoice,
+      { authorizationHeader: authHeader ?? undefined },
     );
 
     return new Response(

--- a/supabase/functions/sugerir-preco/index.ts
+++ b/supabase/functions/sugerir-preco/index.ts
@@ -32,18 +32,24 @@ async function clearDerivedSuggestionData(
   supabaseClient: ReturnType<typeof createClient>,
   itemId: string,
 ) {
-  await supabaseClient
+  const { error: deleteMatchesError } = await supabaseClient
     .from("list_item_product_matches")
     .delete()
     .eq("list_item_id", itemId);
+  if (deleteMatchesError) {
+    throw deleteMatchesError;
+  }
 
-  await supabaseClient
+  const { error: clearSuggestionError } = await supabaseClient
     .from("list_items")
     .update({
       preco_sugerido: null,
       unidade_preco_sugerido: null,
     })
     .eq("id", itemId);
+  if (clearSuggestionError) {
+    throw clearSuggestionError;
+  }
 }
 
 serve(async (req) => {
@@ -96,8 +102,11 @@ serve(async (req) => {
       return new Response(JSON.stringify({ message: "Nenhum produto compatível encontrado." }), { status: 200 });
     }
 
-    // Atualiza matches
-    await supabaseClient.from("list_item_product_matches").delete().eq("list_item_id", itemId);
+    const { error: deleteMatchesError } = await supabaseClient
+      .from("list_item_product_matches")
+      .delete()
+      .eq("list_item_id", itemId);
+    if (deleteMatchesError) throw deleteMatchesError;
     
     const newMatches = matchedProducts.map((product: any) => ({
       list_item_id: itemId,
@@ -105,7 +114,10 @@ serve(async (req) => {
       similarity_score: product.similarity
     }));
 
-    await supabaseClient.from("list_item_product_matches").insert(newMatches);
+    const { error: insertMatchesError } = await supabaseClient
+      .from("list_item_product_matches")
+      .insert(newMatches);
+    if (insertMatchesError) throw insertMatchesError;
 
     // CORREÇÃO: Encontra o produto MAIS SIMILAR que tenha preço (o primeiro da lista com preço)
     // matchedProducts já vem ordenado por similaridade decrescente da RPC
@@ -119,17 +131,25 @@ serve(async (req) => {
         .eq("id", bestMatch.id)
         .single();
 
-      await supabaseClient.from("list_items").update({
-        preco_sugerido: bestMatch.valor_unitario,
-        unidade_preco_sugerido: productData?.unidade_medida || null
-      }).eq("id", itemId);
+      const { error: updateSuggestionError } = await supabaseClient
+        .from("list_items")
+        .update({
+          preco_sugerido: bestMatch.valor_unitario,
+          unidade_preco_sugerido: productData?.unidade_medida || null
+        })
+        .eq("id", itemId);
+      if (updateSuggestionError) throw updateSuggestionError;
 
       console.log(`Preço sugerido de ${bestMatch.valor_unitario} (Unidade: ${productData?.unidade_medida}) para "${itemName}" (baseado no match mais similar: "${bestMatch.nome}" com ${(bestMatch.similarity * 100).toFixed(1)}%).`);
     } else {
-      await supabaseClient.from("list_items").update({
-        preco_sugerido: null,
-        unidade_preco_sugerido: null
-      }).eq("id", itemId);
+      const { error: clearSuggestionError } = await supabaseClient
+        .from("list_items")
+        .update({
+          preco_sugerido: null,
+          unidade_preco_sugerido: null
+        })
+        .eq("id", itemId);
+      if (clearSuggestionError) throw clearSuggestionError;
       console.log(`Produtos similares a "${itemName}" encontrados, mas nenhum com preço.`);
     }
 


### PR DESCRIPTION
## Resumo
- alinha o fluxo de scrape-nfce ao modelo documentado de persistência no contexto autenticado do usuário
- limpa matches e preço sugerido de forma consistente em sugerir-preco
- evita uso de BuildContext depois do fechamento da rota no scanner de nota
- trata avatar e metadata como opcionais com fallback visual seguro

## Validação
- flutter analyze
- flutter test falhou em testes já existentes de ListDetailsBloc por mock de realtime em test/mocks.dart e test/list_details/presentation/bloc/list_details_bloc_test.dart
- não foi possível rodar deno fmt porque deno não está disponível no ambiente

Fixes #24
Fixes #26
Fixes #30
Fixes #35